### PR TITLE
Don't pass program name in with args

### DIFF
--- a/.files/dest/newlib/main.tpl.go
+++ b/.files/dest/newlib/main.tpl.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	fmt.Println("Hello, World!")
-	conf := cli.ParseArgs(os.Args...)
+	conf := cli.ParseArgs(os.Args[1:]...)
 	bin, err := json.MarshalIndent(conf, "", "  ")
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
When using subcommands, this seems to break because it's trying to interpret the program name as a subcommand.